### PR TITLE
Add css appendix-table class

### DIFF
--- a/src/css/aas-specs.css
+++ b/src/css/aas-specs.css
@@ -86,6 +86,9 @@
   .table-with-appendix-table {
     margin-bottom: 0;
   }
+  .appendix-table {
+    margin-top: 0;
+  }
 
   /* Header column */
   tbody tr th {


### PR DESCRIPTION
Added css appendix-table class, where tables get `margin-top = 0`. This is important to visually merge sequential tables